### PR TITLE
do not get source if it's not needed

### DIFF
--- a/src/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/src/AppiumLibrary/keywords/_applicationmanagement.py
@@ -136,9 +136,13 @@ class _ApplicationManagementKeywords(KeywordGroup):
         The `loglevel` argument defines the used log level. Valid log levels are
         `WARN`, `INFO` (default), `DEBUG`, `TRACE` and `NONE` (no logging).
         """
-        source = self._current_application().page_source
-        self._log(source, loglevel.upper())
-        return source
+        ll = loglevel.upper()
+        if ll == 'NONE':
+            return ''
+        else:
+            source = self._current_application().page_source
+            self._log(source, ll)
+            return source
 
     def go_back(self):
         """Goes one step backward in the browser history."""


### PR DESCRIPTION
with loglevel 'NONE' it's useless to retrieve the source because it's not used.
This should be avoided, because:
- appium/android is somewhat unreliable with the ".page_source" (getting the page source sometimes breaks things on appium/android side causing restarts/retries)
- Getting the source slows down the execution up to 1 second each time the source is retrieved. 

For example when executing the `element_should_be_enabled()` KW the execution time  is split like this:
- `is_enabled()` takes ~200ms
- `page_source` takes ~400ms

Using this in combination with `Wait until keyword succeeds` KW makes things even worse.
E.g. `Wait until keyword succeeds   10s    0.1s   element_should_be_enabled  ${my_ele}    NONE`  the code spends most of it's time waiting for the page source although it does not use the source anywhere...