### PR TITLE
register_keyword_to_run_on_failure() fix

### DIFF
--- a/src/AppiumLibrary/keywords/_runonfailure.py
+++ b/src/AppiumLibrary/keywords/_runonfailure.py
@@ -40,10 +40,10 @@ class _RunOnFailureKeywords(KeywordGroup):
         or newer and it does not work on IronPython at all.
         """
         old_keyword = self._run_on_failure_keyword
-        old_keyword_text = old_keyword if old_keyword is not None else "No keyword"
+        old_keyword_text = old_keyword if old_keyword is not None else "Nothing"
 
         new_keyword = keyword if keyword.strip().lower() != "nothing" else None
-        new_keyword_text = new_keyword if new_keyword is not None else "No keyword"
+        new_keyword_text = new_keyword if new_keyword is not None else "Nothing"
 
         self._run_on_failure_keyword = new_keyword
         self._info('%s will be run on failure.' % new_keyword_text)


### PR DESCRIPTION
one could end up with `` Keyword 'No keyword' could not be run on failure: No keyword with name 'No keyword' found.`` errors.
For example, like this:
```
register_keyword_to_run_on_failure("Nothing")                   #self._run_on_failure_keyword=None
old_kw = register_keyword_to_run_on_failure("My Error Kw")      #self._run_on_failure_keyword="My Error Kw"
register_keyword_to_run_on_failure(old_kw)      				#self._run_on_failure_keyword="no keyword"
```

This fails because there's no such thing as "no keyword" in RF