### PR TITLE
Adding a new keyword to return the capability value by capability name.

### DIFF
--- a/src/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/src/AppiumLibrary/keywords/_applicationmanagement.py
@@ -204,7 +204,7 @@ class _ApplicationManagementKeywords(KeywordGroup):
 
     def get_capability(self, capability_name):
         """
-        Return the capability value by capability name
+        Return the desired capability value by desired capability name
         """
         try:
             capability = self._current_application().capabilities[capability_name]

--- a/src/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/src/AppiumLibrary/keywords/_applicationmanagement.py
@@ -202,6 +202,16 @@ class _ApplicationManagementKeywords(KeywordGroup):
         """
         self._current_application().get(url)
 
+    def get_capability(self, capability_name):
+        """
+        Return the capability value by capability name
+        """
+        try:
+            capability = self._current_application().capabilities[capability_name]
+        except Exception as e:
+            raise e
+        return capability
+        
     # Private
 
     def _current_application(self):


### PR DESCRIPTION
I am using Appium Library to test using a mobile testing grid and it will be awesome to have the device name in which that specific test is running. For that, this new keyword works perfectly. Instead of creating a specific keyword to return the device name we thought that Get Capability will be more useful in a bunch of situations.