### PR TITLE
Added log-level filter

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -84,10 +84,10 @@ class _ApplicationManagementKeywords(KeywordGroup):
     def launch_application(self):
         """ Launch application. Application can be launched while Appium session running.
         This keyword can be used to launch application during test case or between test cases.
-        
+
         This keyword works while `Open Application` has a test running. This is good practice to `Launch Application`
         and `Quit Application` between test cases. As Suite Setup is `Open Application`, `Test Setup` can be used to `Launch Application`
-       
+
         Example (syntax is just a representation, refer to RF Guide for usage of Setup/Teardown):
         | [Setup Suite] |
         |  | Open Application | http://localhost:4723/wd/hub | platformName=Android | deviceName=192.168.56.101:5555 | app=${CURDIR}/demoapp/OrangeDemoApp.apk |
@@ -99,27 +99,27 @@ class _ApplicationManagementKeywords(KeywordGroup):
         |  | Quit Application |
         | [Suite Teardown] |
         |  | Close Application |
-        
+
         See `Quit Application` for quiting application but keeping Appium sesion running.
-        
+
         New in AppiumLibrary 1.4.6
         """
         driver = self._current_application()
         driver.launch_app()
 
     def quit_application(self):
-        """ Quit application. Application can be quit while Appium session is kept alive. 
+        """ Quit application. Application can be quit while Appium session is kept alive.
         This keyword can be used to close application during test case or between test cases.
-        
+
         See `Launch Application` for an explanation.
-        
+
         New in AppiumLibrary 1.4.6
         """
         driver = self._current_application()
         driver.close_app()
 
     def reset_application(self):
-        """ Reset application. Open Application can be reset while Appium session is kept alive.       
+        """ Reset application. Open Application can be reset while Appium session is kept alive.
         """
         driver = self._current_application()
         driver.reset()
@@ -232,24 +232,24 @@ class _ApplicationManagementKeywords(KeywordGroup):
 
     def get_window_height(self):
         """Get current device height.
-        
+
         Example:
         | ${width}       | Get Window Height |
         | ${height}      | Get Window Height |
         | Click A Point  | ${width           | ${height} |
-               
+
         New in AppiumLibrary 1.4.5
         """
         return self._current_application().get_window_size()['height']
 
     def get_window_width(self):
         """Get current device width.
-        
+
         Example:
         | ${width}       | Get Window Height |
         | ${height}      | Get Window Height |
         | Click A Point  | ${width           | ${height} |
-        
+
         New in AppiumLibrary 1.4.5
         """
         return self._current_application().get_window_size()['width']
@@ -277,7 +277,7 @@ class _ApplicationManagementKeywords(KeywordGroup):
         except Exception as e:
             raise e
         return capability
-        
+
     # Private
 
     def _current_application(self):

--- a/AppiumLibrary/keywords/_logging.py
+++ b/AppiumLibrary/keywords/_logging.py
@@ -7,11 +7,29 @@ from .keywordgroup import KeywordGroup
 
 
 class _LoggingKeywords(KeywordGroup):
+    LOG_LEVEL_DEBUG = ['DEBUG']
+    LOG_LEVEL_INFO = ['DEBUG', 'INFO']
+    LOG_LEVEL_WARN = ['DEBUG', 'INFO', 'WARN']
 
-    # Private
+    @property
+    def _log_level(self):
+        return BuiltIn().get_variable_value("${APPIUM_LOG_LEVEL}", default='DEBUG')
 
     def _debug(self, message):
-        logger.debug(message)
+        if self._log_level in self.LOG_LEVEL_DEBUG:
+            logger.debug(message)
+
+    def _info(self, message):
+        if self._log_level in self.LOG_LEVEL_INFO:
+            logger.info(message)
+
+    def _warn(self, message):
+        if self._log_level in self.LOG_LEVEL_WARN:
+            logger.warn(message)
+
+    def _html(self, message):
+        if self._log_level in self.LOG_LEVEL_INFO:
+            logger.info(message, True, False)
 
     def _get_log_dir(self):
         variables = BuiltIn().get_variables()
@@ -19,12 +37,6 @@ class _LoggingKeywords(KeywordGroup):
         if logfile != 'NONE':
             return os.path.dirname(logfile)
         return variables['${OUTPUTDIR}']
-
-    def _html(self, message):
-        logger.info(message, True, False)
-
-    def _info(self, message):
-        logger.info(message)
 
     def _log(self, message, level='INFO'):
         level = level.upper()
@@ -44,5 +56,3 @@ class _LoggingKeywords(KeywordGroup):
         self._info('\n'.join(msg))
         return items
 
-    def _warn(self, message):
-        logger.warn(message)


### PR DESCRIPTION
When troubleshooting "my non-appiumLibrary" code the AppiumLibrary logs were sometimes messing up the RF log file, e.g. if the page source gets logged that is in the worst cases one full screen of log entry.

Added `${APPIUM_LOG_LEVEL}` global variable for suppressing appiumLibrary logs i.e. with `${APPIUM_LOG_LEVEL}   INFO` only logs with INFO level (and higher) are written into the RF log.

If the `${APPIUM_LOG_LEVEL}` is not defined all logs are written as before = in this case the old logging behaviour is unchanged.