### PR TITLE
Fix the click element if locator is a WebElement instance

### DIFF
--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -572,7 +572,7 @@ class _ElementKeywords(KeywordGroup):
                 return elements[0]
         elif isinstance(locator, WebElement):
             if first_only:
-                return elements[0]
+                return locator
             else:
                 elements = [locator]
         # do some other stuff here like deal with list of webelements

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -571,7 +571,10 @@ class _ElementKeywords(KeywordGroup):
                 if len(elements) == 0: return None
                 return elements[0]
         elif isinstance(locator, WebElement):
-            elements = [locator]
+            if first_only:
+                return elements[0]
+            else:
+                elements = [locator]
         # do some other stuff here like deal with list of webelements
         # ... or raise locator/element specific error if required
         return elements


### PR DESCRIPTION
_element_find function should return just an element if caller need an element

![image](https://user-images.githubusercontent.com/2438992/56874810-a50fdf00-6a66-11e9-9893-23a846ae585f.png)

This function was broken by the commit 9f430aca5f2932cf201f026f85c7d9353f3a3f82