### PR TITLE
Added new Execute Adb Shell keyword

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -225,7 +225,7 @@ class _ApplicationManagementKeywords(KeywordGroup):
 
         Returns the exit code of ADB shell.
 
-        Requires server flag --relaxed-security to be set.
+        Requires server flag --relaxed-security to be set on Appium server.
         """
         return self._current_application().execute_script('mobile: shell', {
             'command': command,

--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -214,6 +214,15 @@ class _ApplicationManagementKeywords(KeywordGroup):
         """
         return self._current_application().execute_async_script(script)
 
+    def execute_adb_shell(self, command, *args):
+        """
+        Execute Adb shell
+        """
+        return self._current_application().execute_script('mobile: shell', {
+            'command': command,
+            'args': list(args)
+        })
+        
     def go_back(self):
         """Goes one step backward in the browser history."""
         self._current_application().back()

--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -216,7 +216,16 @@ class _ApplicationManagementKeywords(KeywordGroup):
 
     def execute_adb_shell(self, command, *args):
         """
-        Execute Adb shell
+        Execute ADB shell commands
+
+        Android only.
+
+        - _command_ - The ABD shell command
+        - _args_ - Arguments to send to command
+
+        Returns the exit code of ADB shell.
+
+        Requires server flag --relaxed-security to be set.
         """
         return self._current_application().execute_script('mobile: shell', {
             'command': command,


### PR DESCRIPTION
Implements new `Execute Abd Shell` keyword.

Needed special implementation to do `mobile: shell` adb command. Might have metter ways. what you think?

Reference: http://appium.io/docs/en/writing-running-appium/android/android-shell/