### PR TITLE
Fix for issue #255: Click Button keyword doesn't work on python 3

### DIFF
--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -516,7 +516,7 @@ class _ElementKeywords(KeywordGroup):
         return platform_class_dict.get(self._get_platform())
 
     def _is_support_platform(self, platform_class_dict):
-        return platform_class_dict.has_key(self._get_platform())
+        return self._get_platform() in platform_class_dict
 
     def _click_element_by_class_name(self, class_name, index_or_name):
         element = self._find_element_by_class_name(class_name, index_or_name)


### PR DESCRIPTION
"has_key" does not exist in Python3, "in" is used

## Implements

## Fixing

 #255 Click Button keyword doesn't work on python 3
