### PR TITLE
Issue #304

### DIFF
--- a/AppiumLibrary/keywords/_touch.py
+++ b/AppiumLibrary/keywords/_touch.py
@@ -45,8 +45,12 @@ class _TouchKeywords(KeywordGroup):
         _*NOTE: *_
         Android 'Swipe' is not working properly, use ``offset_x`` and ``offset_y`` as if these are destination points.
         """
+        x_start = int(start_x)
+        x_offset = int(offset_x)
+        y_start = int(start_y)
+        y_offset = int(offset_y)
         driver = self._current_application()
-        driver.swipe(start_x, start_y, offset_x, offset_y, duration)
+        driver.swipe(x_start, y_start, x_offset, y_offset, duration)
 
     def swipe_by_percent(self, start_x, start_y, end_x, end_y, duration=1000):
         """


### PR DESCRIPTION
Add int cast to parameters start_x, start_y, offset_x, offset_y in swipe function 
Note : Direct call from Robotframework cast str into int
Call from swipe_by_percent_method cast float to int

## Implements

## Fixing
