### PR TITLE
Add library argument and keyword to set sleep between wait until loop

### DIFF
--- a/AppiumLibrary/__init__.py
+++ b/AppiumLibrary/__init__.py
@@ -79,7 +79,7 @@ class AppiumLibrary(
     ROBOT_LIBRARY_SCOPE = 'GLOBAL'
     ROBOT_LIBRARY_VERSION = VERSION
 
-    def __init__(self, timeout=5, run_on_failure='Capture Page Screenshot'):
+    def __init__(self, timeout=5, run_on_failure='Capture Page Screenshot', sleep_between_wait_loop=0.2):
         """AppiumLibrary can be imported with optional arguments.
 
         ``timeout`` is the default timeout used to wait for all waiting actions.
@@ -92,12 +92,16 @@ class AppiumLibrary(
         Using the value `No Operation` will disable this feature altogether. See
         `Register Keyword To Run On Failure` keyword for more information about this
         functionality.
+        
+        ``sleep_between_wait_loop`` is the default sleep used to wait between loop in all wait until keywords
 
         Examples:
         | Library | AppiumLibrary | 10 | # Sets default timeout to 10 seconds                                                                             |
         | Library | AppiumLibrary | timeout=10 | run_on_failure=No Operation | # Sets default timeout to 10 seconds and does nothing on failure           |
+        | Library | AppiumLibrary | timeout=10 | sleep_between_wait_loop=0.3 | # Sets default timeout to 10 seconds and sleep 300 ms between wait loop    |
         """
         for base in AppiumLibrary.__bases__:
             base.__init__(self)
         self.set_appium_timeout(timeout)
         self.register_keyword_to_run_on_failure(run_on_failure)
+        self.set_sleep_between_wait_loop(sleep_between_wait_loop)

--- a/AppiumLibrary/keywords/_waiting.py
+++ b/AppiumLibrary/keywords/_waiting.py
@@ -115,10 +115,10 @@ class _WaitingKeywords(KeywordGroup):
 
         self._wait_until_no_error(timeout, check_present)
 
-    def set_sleep_between_wait(self, seconds=0.2):
+    def set_sleep_between_wait_loop(self, seconds=0.2):
         """Sets the sleep in seconds used by wait until loop.
         
-        If you use the remote appium server, the default value is not recommend because 
+        If you use the remote appium server, the default value is not recommended because 
         it is another 200ms overhead to the network latency and will slow down your test
         execution.
         """
@@ -126,7 +126,7 @@ class _WaitingKeywords(KeywordGroup):
         self._sleep_between_wait = robot.utils.timestr_to_secs(seconds)
         return old_sleep
     
-    def get_sleep_between_wait(self):
+    def get_sleep_between_wait_loop(self):
         """Gets the sleep between wait loop in seconds that is used by wait until keywords.
         """
         return robot.utils.secs_to_timestr(self._sleep_between_wait)

--- a/AppiumLibrary/keywords/_waiting.py
+++ b/AppiumLibrary/keywords/_waiting.py
@@ -125,7 +125,12 @@ class _WaitingKeywords(KeywordGroup):
         old_sleep = self._sleep_between_wait
         self._sleep_between_wait = robot.utils.timestr_to_secs(seconds)
         return old_sleep
-        
+    
+    def get_sleep_between_wait(self):
+        """Gets the sleep between wait loop in seconds that is used by wait until keywords.
+        """
+        return robot.utils.secs_to_timestr(self._sleep_between_wait)
+    
     # Private
 
     def _wait_until(self, timeout, error, function, *args):

--- a/AppiumLibrary/keywords/_waiting.py
+++ b/AppiumLibrary/keywords/_waiting.py
@@ -4,6 +4,10 @@ from .keywordgroup import KeywordGroup
 
 
 class _WaitingKeywords(KeywordGroup):
+    
+    def __init__(self):
+        self._sleep_between_wait = 0.2
+        
     def wait_until_element_is_visible(self, locator, timeout=None, error=None):
         """Waits until element specified with `locator` is visible.
 
@@ -111,6 +115,17 @@ class _WaitingKeywords(KeywordGroup):
 
         self._wait_until_no_error(timeout, check_present)
 
+    def set_sleep_between_wait(self, seconds=0.2):
+        """Sets the sleep in seconds used by wait until loop.
+        
+        If you use the remote appium server, the default value is not recommend because 
+        it is another 200ms overhead to the network latency and will slow down your test
+        execution.
+        """
+        old_sleep = self._sleep_between_wait
+        self._sleep_between_wait = robot.utils.timestr_to_secs(seconds)
+        return old_sleep
+        
     # Private
 
     def _wait_until(self, timeout, error, function, *args):
@@ -131,7 +146,7 @@ class _WaitingKeywords(KeywordGroup):
             if time.time() > maxtime:
                 self.log_source()
                 raise AssertionError(timeout_error)
-            time.sleep(0.2)
+            time.sleep(self._sleep_between_wait)
 
     def _format_timeout(self, timeout):
         timeout = robot.utils.timestr_to_secs(timeout) if timeout is not None else self._timeout_in_secs


### PR DESCRIPTION
Sleep between wait until loop is an overhead to each wait loop if the appium server sits remotely.
With this PR, the test execution time over the network reduce gradually.

## Implements

- Library argument to set sleep between wait until loop

- Add Set/Get sleep between wait until loop


