### PR TITLE
Elementid rather than element since appium "1.22"

### DIFF
--- a/AppiumLibrary/keywords/_touch.py
+++ b/AppiumLibrary/keywords/_touch.py
@@ -101,13 +101,13 @@ class _TouchKeywords(KeywordGroup):
         """Scrolls down to element"""
         driver = self._current_application()
         element = self._element_find(locator, True, True)
-        driver.execute_script("mobile: scroll", {"direction": 'down', 'element': element.id})
+        driver.execute_script("mobile: scroll", {"direction": 'down', 'elementid': element.id})
 
     def scroll_up(self, locator):
         """Scrolls up to element"""
         driver = self._current_application()
         element = self._element_find(locator, True, True)
-        driver.execute_script("mobile: scroll", {"direction": 'up', 'element': element.id})
+        driver.execute_script("mobile: scroll", {"direction": 'up', 'elementid': element.id})
 
     def long_press(self, locator, duration=1000):
         """ Long press the element with optional duration """


### PR DESCRIPTION
## Fixing

Seems that current Appium (1.21) uses element**id** rather than just element for the scroll command. Documentation says this is since version 1.22 (which just has a release candidate that I can see) but I can confirm I am seeing this in 1.21 locally.

https://github.com/appium/appium-xcuitest-driver#mobile-scroll
![image](https://user-images.githubusercontent.com/3010366/129970190-a429bc1d-e893-4660-a02e-90646cde2e58.png)

The pull request in question: https://github.com/appium/appium-xcuitest-driver/pull/1305