### PR TITLE
Adding new keyword adb command timeout

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -231,7 +231,27 @@ class _ApplicationManagementKeywords(KeywordGroup):
             'command': command,
             'args': list(args)
         })
-        
+
+    def execute_adb_shell_timeout(self, command, timeout, *args):
+        """
+        Execute ADB shell commands
+
+        Android only.
+
+        - _command_ - The ABD shell command
+        - _timeout_ - Timeout to be applied to command
+        - _args_ - Arguments to send to command
+
+        Returns the exit code of ADB shell.
+
+        Requires server flag --relaxed-security to be set on Appium server.
+        """
+        return self._current_application().execute_script('mobile: shell', {
+            'command': command,
+            'args': list(args),
+            'timeout': timeout
+        })
+
     def go_back(self):
         """Goes one step backward in the browser history."""
         self._current_application().back()


### PR DESCRIPTION
## Implements
Adding a new keyword 'execute_adb_shell_timeout' to be able to use timeout option in adb shell command.
This timeout option is very useful when we use some long commands as adb logs to grep logs from android. 
This option is described in:
http://appium.io/docs/en/writing-running-appium/android/android-shell/#supported-arguments

To maintain backward capability, we have choose to create a new keyword instead of using the implemented one.

## Fixing
NA