### PR TITLE
Support applications with multiple webviews.  Add scrolling to the visible webview.

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -340,6 +340,13 @@ class _ApplicationManagementKeywords(KeywordGroup):
         """
         self._current_application().switch_to.parent_frame()
 
+    def switch_to_window(self, window_name):
+        """
+        Switch to a new webview window if the application contains multiple webviews
+        """
+        self._current_application().switch_to.window(window_name)
+
+
     def go_to_url(self, url):
         """
         Opens URL in default web browser.
@@ -359,6 +366,21 @@ class _ApplicationManagementKeywords(KeywordGroup):
         except Exception as e:
             raise e
         return capability
+
+    def get_window_title(self):
+        """Get the current Webview window title."""
+        return self._current_application().title
+
+    def get_window_url(self):
+        """Get the current Webview window URL."""
+        return self._current_application().current_url
+
+
+    def get_windows(self):
+        """Get available Webview windows."""
+        print(self._current_application().window_handles)
+        return self._current_application().window_handles
+
 
     # Private
 

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -380,6 +380,20 @@ class _ElementKeywords(KeywordGroup):
         elif isinstance(locator, WebElement):
             return locator
 
+    def get_webelements_no_error(self, locator):
+        """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.
+
+        Example:
+        | @{elements}    | Get Webelements | id=my_element |
+        | Click Element  | @{elements}[2]  |               |
+
+        This keyword was changed in AppiumLibrary 1.4 in following ways:
+        - Name is changed from `Get Elements` to current one.
+        - Deprecated argument ``fail_on_error``, use `Run Keyword and Ignore Error` if necessary.
+
+        New in AppiumLibrary 1.4.
+        """
+        return self._element_find(locator, False, False)
 
     def get_webelements(self, locator):
         """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -366,6 +366,21 @@ class _ElementKeywords(KeywordGroup):
         self._current_application().execute_script(script, element)
         return element
 
+    def get_webelement_in_webelement(self, element, locator):
+            # def _element_find(self, locator, first_only, required, tag=None):
+        elements = None
+        if isstr(locator):
+            _locator = locator
+            elements = self._element_finder.find(element, _locator, None)
+            if len(elements) == 0:
+                raise ValueError("Element locator '" + locator + "' did not match any elements.")
+            if len(elements) == 0: 
+                return None
+            return elements[0]
+        elif isinstance(locator, WebElement):
+            return locator
+
+
     def get_webelements(self, locator):
         """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.
 

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -372,7 +372,7 @@ class _ElementKeywords(KeywordGroup):
         objects matching ``locator`` that is a child of argument element.
 
         This is useful when your HTML doesn't properly have id or name elements on all elements.
-        So the user can find an element with a tag and then serach that elmements children.
+        So the user can find an element with a tag and then search that elmements children.
         """
         elements = None
         if isstr(locator):
@@ -385,21 +385,6 @@ class _ElementKeywords(KeywordGroup):
             return elements[0]
         elif isinstance(locator, WebElement):
             return locator
-
-    def get_webelements_no_error(self, locator):
-        """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.
-
-        Example:
-        | @{elements}    | Get Webelements | id=my_element |
-        | Click Element  | @{elements}[2]  |               |
-
-        This keyword was changed in AppiumLibrary 1.4 in following ways:
-        - Name is changed from `Get Elements` to current one.
-        - Deprecated argument ``fail_on_error``, use `Run Keyword and Ignore Error` if necessary.
-
-        New in AppiumLibrary 1.4.
-        """
-        return self._element_find(locator, False, False)
 
     def get_webelements(self, locator):
         """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -347,6 +347,25 @@ class _ElementKeywords(KeywordGroup):
         """
         return self._element_find(locator, True, True)
 
+    def scroll_element_into_view(self, locator):
+        """Scrolls an element from given ``locator`` into view.
+        Arguments:
+        - ``locator``: The locator to find requested element. Key attributes for
+                       arbitrary elements are ``id`` and ``name``. See `introduction` for
+                       details about locating elements.
+        Examples:
+        | Scroll Element Into View | css=div.class |
+        """
+        if isinstance(locator, WebElement):
+            element = locator
+        else:
+            self._info("Scrolling element '%s' into view." % locator)
+            element = self._element_find(locator, True, True)
+        script = 'arguments[0].scrollIntoView()'
+        # pylint: disable=no-member
+        self._current_application().execute_script(script, element)
+        return element
+
     def get_webelements(self, locator):
         """Returns list of [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] objects matching ``locator``.
 

--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -367,7 +367,13 @@ class _ElementKeywords(KeywordGroup):
         return element
 
     def get_webelement_in_webelement(self, element, locator):
-            # def _element_find(self, locator, first_only, required, tag=None):
+        """ 
+        Returns a single [http://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.remote.webelement|WebElement] 
+        objects matching ``locator`` that is a child of argument element.
+
+        This is useful when your HTML doesn't properly have id or name elements on all elements.
+        So the user can find an element with a tag and then serach that elmements children.
+        """
         elements = None
         if isstr(locator):
             _locator = locator


### PR DESCRIPTION
## Implements
This provides the users with the ability to select navigate through multiple webviews after they have selected the webview context (instead of NATIVE_APP).
This also provides a built in way to scroll to an element to make it visible.
This provides the ability to narrow a search for a webelement to a child of an existing webelement. 

## Fixing
