### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help
 
 help:
-	@echo targes: version, generate_doc, pypi_upload, clean_pyc, android_demo, ios_demo, demo, unittest, test
+	@echo targets: version, generate_doc, pypi_upload, clean_pyc, android_demo, ios_demo, demo, unittest, test
 
 generate_doc: 
 	VENV/bin/python -m robot.libdoc ./AppiumLibrary/ ./doc/AppiumLibrary.html
@@ -35,7 +35,7 @@ ios_demo:
 demo:android_demo ios_demo
 
 test_requirements:
-    python -m pip install -U -r test_require.txt
+	python -m pip install -U -r test_require.txt
 
 unittest: test_requirements
 	python setup.py test


### PR DESCRIPTION
<img width="730" alt="image" src="https://user-images.githubusercontent.com/23168063/199409506-f8f45c6c-1060-471a-9283-3bb4d8e933a2.png">


## Implements

There was [Make error: missing separator](https://stackoverflow.com/questions/920413/make-error-missing-separator) error in GitHub action ci section. To overcome this issue, here are such improvements:

## Fixing

* Typo fix in help
* Indentation fix in test_requirements