### PR TITLE
Remove appended dot in wait_activity

### DIFF
--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -163,10 +163,6 @@ class _AndroidUtilsKeywords(KeywordGroup):
          - _timeout_ - max wait time, in seconds
          - _interval_ - sleep interval between retries, in seconds
         """
-
-        if not activity.startswith('.'):
-            activity = ".%s" % activity
-
         driver = self._current_application()
         if not driver.wait_activity(activity=activity, timeout=float(timeout), interval=float(interval)):
             raise TimeoutException(msg="Activity %s never presented, current activity: %s" % (activity, self.get_activity()))


### PR DESCRIPTION
Remove appending of dot in Android wait_activity

based on: https://github.com/serhatbolsu/robotframework-appiumlibrary/pull/169
related: https://github.com/serhatbolsu/robotframework-appiumlibrary/issues/336

## Fixing
- Remove automatically adding a "." prefix to Android activity name when calling wait_activity