### PR TITLE
Added optional `first_only` parameter to `Get Text`

### DIFF
--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -470,16 +470,18 @@ class _ElementKeywords(KeywordGroup):
         self._info("Element '%s' rect: %s " % (locator, element_rect))
         return element_rect
 
-    def get_text(self, locator):
+    def get_text(self, locator, first_only: bool = True):
         """Get element text (for hybrid and mobile browser use `xpath` locator, others might cause problem)
 
-        Example:
+        first_only parameter allow to get the text from the 1st match (Default) or a list of text from all match.
 
-        | ${text} | Get Text | //*[contains(@text,'foo')] |
+        Example:
+        | ${text} | Get Text | //*[contains(@text,'foo')] |          |
+        | @{text} | Get Text | //*[contains(@text,'foo')] | ${False} |
 
         New in AppiumLibrary 1.4.
         """
-        text = self._get_text(locator)
+        text = self._get_text(locator, first_only)
         self._info("Element '%s' text is '%s' " % (locator, text))
         return text
 
@@ -670,10 +672,12 @@ class _ElementKeywords(KeywordGroup):
                 _xpath = u'//*[contains(@{},"{}")]'.format('text', text)
             return self._element_find(_xpath, True, True)
 
-    def _get_text(self, locator):
-        element = self._element_find(locator, True, True)
+    def _get_text(self, locator, first_only: bool = True):
+        element = self._element_find(locator, first_only, True)
         if element is not None:
-            return element.text
+            if first_only:
+                return element.text
+            return [el.text for el in element]
         return None
 
     def _is_text_present(self, text):


### PR DESCRIPTION
Small but useful feature

If one locator is present many time in the page
`Get Text` only returned the 1st match. I cannot verify the text display on my droplist with accuracy.

Therefore, I extended `Get Text` capability in my local repository:

## Implements
    * Be able to get the text from all elements matching one locator
    * Default behavior not changed

