### PR TITLE
fix: Update Server CLI Args link in _applicationmanagement.py

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -40,7 +40,7 @@ class _ApplicationManagementKeywords(KeywordGroup):
     def open_application(self, remote_url, alias=None, **kwargs):
         """Opens a new application to given Appium server.
         Capabilities of appium server, Android and iOS,
-        Please check https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/server-args.md
+        Please check https://appium.io/docs/en/2.1/cli/args/
         | *Option*            | *Man.* | *Description*     |
         | remote_url          | Yes    | Appium server url |
         | alias               | no     | alias             |


### PR DESCRIPTION
## Implements

## Fixing
Broken link for [Old Server-args](https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/server-args.md) link should be replaced with new doc page https://appium.io/docs/en/2.1/cli/args/