### PR TITLE
Activity names in Android cannot start with a period (.) in any Android version.

### DIFF
--- a/AppiumLibrary/keywords/_android_utils.py
+++ b/AppiumLibrary/keywords/_android_utils.py
@@ -164,9 +164,6 @@ class _AndroidUtilsKeywords(KeywordGroup):
          - _interval_ - sleep interval between retries, in seconds
         """
 
-        if not activity.startswith('.'):
-            activity = ".%s" % activity
-
         driver = self._current_application()
         if not driver.wait_activity(activity=activity, timeout=float(timeout), interval=float(interval)):
             raise TimeoutException(msg="Activity %s never presented, current activity: %s" % (activity, self.get_activity()))


### PR DESCRIPTION
**## Fixing**
removed "." being appended in the activity name in the wait_activity keyword