### PR TITLE
edit Appium-python-clinet version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='robotframework-appiumlibrary',
           'decorator >= 3.3.2',
           'robotframework >= 2.6.0',
           'docutils >= 0.8.1',
-          'selenium >=4.0,<=4.9',
+          'selenium >=4.12.0',
           'Appium-Python-Client == 3.2.1',
           'kitchen >= 1.2.4',
           'six >= 1.10.0'

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='robotframework-appiumlibrary',
           'robotframework >= 2.6.0',
           'docutils >= 0.8.1',
           'selenium >=4.0,<=4.9',
-          'Appium-Python-Client >= 2.7.1, < 4.0.0',
+          'Appium-Python-Client == 3.2.1',
           'kitchen >= 1.2.4',
           'six >= 1.10.0'
       ],


### PR DESCRIPTION
## Error:
#417

after installing robotframework-appium library, VS-Code throw this error:
"Importing library 'AppiumLibrary' failed: ModuleNotFoundError: No module named 'appium.webdriver.common.touch_action"

and to avoid this error, i find out that [this ](https://github.com/serhatbolsu/robotframework-appiumlibrary/issues/36#issuecomment-2103806729)is the solution. by downgrade "Appium-Python-Client" package.

## Fixing

specify a working version in setup.py which is == 3.2.1

 