### PR TITLE
Fix pypa/gh-action-pypi-publish action usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,16 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/robotframework-appiumlibrary
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -22,7 +27,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Implements

* Fixed pypa/gh-action-pypi-publish action usage
  * https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#usage
* Upgraded other actions' versions
 
## Fixing

> Unable to resolve action `pypa/gh-action-pypi-publish@v1`, unable to find version `v1`

https://github.com/serhatbolsu/robotframework-appiumlibrary/actions/runs/9431673147

![image](https://github.com/serhatbolsu/robotframework-appiumlibrary/assets/23168063/8b0ef721-7f8e-4c37-bbb1-5c421bed9102)
