### PR TITLE
Relaxed requirement for selenium allowing up to and including 4.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='robotframework-appiumlibrary',
           'robotframework >= 2.6.0',
           'docutils >= 0.8.1',
           'selenium >=4.0,<=4.27',
-          'Appium-Python-Client >= 2.7.1, < 4.0.0',
+          'Appium-Python-Client >= 2.7.1, <= 4.3.0',
           'kitchen >= 1.2.4',
           'six >= 1.10.0'
       ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='robotframework-appiumlibrary',
           'decorator >= 3.3.2',
           'robotframework >= 2.6.0',
           'docutils >= 0.8.1',
-          'selenium >=4.0,<=4.16',
+          'selenium >=4.0,<=4.27',
           'Appium-Python-Client >= 2.7.1, < 4.0.0',
           'kitchen >= 1.2.4',
           'six >= 1.10.0'


### PR DESCRIPTION
## Implements

Relaxed requirement for selenium allowing up to and including 4.27 and Appium Python Client up to 4.3.0

## Fixing
