### PR TITLE
feat(android): Allow custom timeout for terminate_application

### DIFF
--- a/AppiumLibrary/keywords/_applicationmanagement.py
+++ b/AppiumLibrary/keywords/_applicationmanagement.py
@@ -308,16 +308,17 @@ class _ApplicationManagementKeywords(KeywordGroup):
         """
         self._current_application().activate_app(app_id)
 
-    def terminate_application(self, app_id):
+    def terminate_application(self, app_id, timeout=500):
         """
         Terminate the given app on the device
 
         Args:
          - app_id - BundleId for iOS. Package name for Android.
+         - timeout - Timeout for the terminate operation in milliseconds (default 500)
 
         New in AppiumLibrary v2
         """
-        return self._current_application().terminate_app(app_id)
+        return self._current_application().terminate_app(app_id, timeout=timeout)
 
     def stop_application(self, app_id, timeout=5000, include_stderr=True):
         """


### PR DESCRIPTION

Description
This PR addresses an issue where the terminate_application method for the UIAutomator 2 driver could fail due to a hardcoded 500ms timeout. This change introduces a configurable timeout parameter, giving users the flexibility to specify a longer duration for application termination.

Motivation and Context
The fixed internal timeout of 500ms was often insufficient for applications that perform cleanup tasks upon closing, or for tests running on slower hardware or simulators. This could lead to premature timeouts and result in flaky, unreliable tests.

By allowing users to set a custom timeout, we can significantly improve the stability of tests that rely on this functionality. This change directly resolves the problem described in issue #14818.

Implementation Details
The terminate_application method now accepts an optional timeout argument, specified in milliseconds.

To maintain backward compatibility and avoid breaking existing tests, the method defaults to the original 500ms timeout if no value is provided.

The underlying logic has been updated to pass this timeout value to the application termination process.

How to Use
Here is an example of how to use the new timeout parameter in a Python test script:

# Default behavior (500ms timeout)
driver.terminate_app('com.example.my-app')

# Custom timeout (e.g., 3 seconds)
driver.terminate_app('com.example.my-app', timeout=3000)

Related Issue
Closes: #14818