### PR TITLE
test: add unit tests for keyword modules

### DIFF
--- a/tests/keywords/test_keyevent.py
+++ b/tests/keywords/test_keyevent.py
@@ -1,0 +1,48 @@
+import unittest
+import mock
+
+from AppiumLibrary.keywords._keyevent import _KeyeventKeywords
+
+
+class KeyeventKeywordsTests(unittest.TestCase):
+    """Tests for _KeyeventKeywords class."""
+
+    def setUp(self):
+        """Set up the test fixture."""
+        self.ke = _KeyeventKeywords()
+        self.mock_driver = mock.Mock()
+        self.ke._current_application = mock.Mock(return_value=self.mock_driver)
+
+    def test_press_keycode(self):
+        """Test press_keycode sends keycode to driver."""
+        self.ke.press_keycode(66)  # KEYCODE_ENTER
+        self.mock_driver.press_keycode.assert_called_once_with(66, None)
+
+    def test_press_keycode_with_metastate(self):
+        """Test press_keycode with meta state."""
+        self.ke.press_keycode(66, metastate=1)  # Shift pressed
+        self.mock_driver.press_keycode.assert_called_once_with(66, 1)
+
+    def test_press_keycode_shift_alt(self):
+        """Test press_keycode with Shift+Alt meta state."""
+        self.ke.press_keycode(29, metastate=3)  # KEYCODE_A with Shift+Alt
+        self.mock_driver.press_keycode.assert_called_once_with(29, 3)
+
+    def test_long_press_keycode(self):
+        """Test long_press_keycode sends long press to driver."""
+        self.ke.long_press_keycode(66)
+        self.mock_driver.long_press_keycode.assert_called_once_with(66, None)
+
+    def test_long_press_keycode_with_metastate(self):
+        """Test long_press_keycode with meta state."""
+        self.ke.long_press_keycode(66, metastate=2)  # Alt pressed
+        self.mock_driver.long_press_keycode.assert_called_once_with(66, 2)
+
+    def test_long_press_keycode_converts_string_to_int(self):
+        """Test that long_press_keycode converts string keycode to int."""
+        self.ke.long_press_keycode('66')
+        self.mock_driver.long_press_keycode.assert_called_once_with(66, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/keywords/test_runonfailure.py
+++ b/tests/keywords/test_runonfailure.py
@@ -1,0 +1,90 @@
+import unittest
+import mock
+
+from AppiumLibrary.keywords._runonfailure import _RunOnFailureKeywords
+
+
+class RunOnFailureKeywordsTests(unittest.TestCase):
+    """Tests for _RunOnFailureKeywords class."""
+
+    def setUp(self):
+        """Set up the test fixture."""
+        self.rof = _RunOnFailureKeywords()
+        self.rof._info = mock.Mock()
+        self.rof._warn = mock.Mock()
+
+    def test_initial_state(self):
+        """Test that initial state has no keyword registered."""
+        self.assertIsNone(self.rof._run_on_failure_keyword)
+        self.assertFalse(self.rof._running_on_failure_routine)
+
+    def test_register_keyword_returns_nothing_when_no_previous_keyword(self):
+        """Test that registering a keyword returns 'Nothing' when no previous keyword was set."""
+        result = self.rof.register_keyword_to_run_on_failure("Log Source")
+        self.assertEqual(result, "Nothing")
+
+    def test_register_keyword_sets_new_keyword(self):
+        """Test that registering a keyword properly sets the new keyword."""
+        self.rof.register_keyword_to_run_on_failure("Log Source")
+        self.assertEqual(self.rof._run_on_failure_keyword, "Log Source")
+
+    def test_register_keyword_returns_previous_keyword(self):
+        """Test that registering a keyword returns the previously registered keyword."""
+        self.rof.register_keyword_to_run_on_failure("Log Source")
+        result = self.rof.register_keyword_to_run_on_failure("Capture Page Screenshot")
+        self.assertEqual(result, "Log Source")
+
+    def test_register_nothing_disables_run_on_failure(self):
+        """Test that registering 'Nothing' disables the run-on-failure functionality."""
+        self.rof.register_keyword_to_run_on_failure("Log Source")
+        self.rof.register_keyword_to_run_on_failure("Nothing")
+        self.assertIsNone(self.rof._run_on_failure_keyword)
+
+    def test_register_nothing_case_insensitive(self):
+        """Test that 'nothing' keyword is case insensitive."""
+        self.rof.register_keyword_to_run_on_failure("Log Source")
+        self.rof.register_keyword_to_run_on_failure("NOTHING")
+        self.assertIsNone(self.rof._run_on_failure_keyword)
+
+    def test_register_nothing_with_whitespace(self):
+        """Test that 'nothing' keyword handles whitespace."""
+        self.rof.register_keyword_to_run_on_failure("Log Source")
+        self.rof.register_keyword_to_run_on_failure("  nothing  ")
+        self.assertIsNone(self.rof._run_on_failure_keyword)
+
+    def test_run_on_failure_does_nothing_when_no_keyword_registered(self):
+        """Test that _run_on_failure does nothing when no keyword is registered."""
+        self.rof._run_on_failure()
+        # Should not raise and should return early
+        self.assertFalse(self.rof._running_on_failure_routine)
+
+    def test_run_on_failure_does_not_run_when_already_running(self):
+        """Test that _run_on_failure does not run when already running."""
+        self.rof._run_on_failure_keyword = "Some Keyword"
+        self.rof._running_on_failure_routine = True
+        # Should return early without changing state
+        self.rof._run_on_failure()
+        self.assertTrue(self.rof._running_on_failure_routine)
+
+    def test_run_on_failure_error_with_warn_method(self):
+        """Test that _run_on_failure_error uses _warn when available."""
+        self.rof._run_on_failure_keyword = "Test Keyword"
+        self.rof._run_on_failure_error("Test error")
+        self.rof._warn.assert_called_once()
+        call_args = self.rof._warn.call_args[0][0]
+        self.assertIn("Test Keyword", call_args)
+        self.assertIn("Test error", call_args)
+
+    def test_run_on_failure_error_raises_when_no_warn_method(self):
+        """Test that _run_on_failure_error raises exception when _warn not available."""
+        # Remove the _warn attribute
+        del self.rof._warn
+        self.rof._run_on_failure_keyword = "Test Keyword"
+        with self.assertRaises(Exception) as context:
+            self.rof._run_on_failure_error("Test error")
+        self.assertIn("Test Keyword", str(context.exception))
+        self.assertIn("Test error", str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/keywords/test_screenrecord.py
+++ b/tests/keywords/test_screenrecord.py
@@ -1,0 +1,83 @@
+import unittest
+import mock
+
+from AppiumLibrary.keywords._screenrecord import _ScreenrecordKeywords
+
+
+class ScreenrecordKeywordsTests(unittest.TestCase):
+    """Tests for _ScreenrecordKeywords class."""
+
+    def setUp(self):
+        """Set up the test fixture."""
+        self.sr = _ScreenrecordKeywords()
+        self.mock_driver = mock.Mock()
+        self.sr._current_application = mock.Mock(return_value=self.mock_driver)
+        self.sr._html = mock.Mock()
+        self.sr._get_log_dir = mock.Mock(return_value='/tmp/logs')
+        # Mock platform detection
+        self.sr._set_output_format = mock.Mock(return_value='mp4')
+
+    def test_initial_state(self):
+        """Test initial state of screen recorder."""
+        sr = _ScreenrecordKeywords()
+        self.assertEqual(sr._screenrecord_index, 0)
+        self.assertIsNone(sr._recording)
+        self.assertIsNone(sr._output_format)
+
+    def test_start_screen_recording(self):
+        """Test starting screen recording."""
+        self.sr.start_screen_recording()
+        self.mock_driver.start_recording_screen.assert_called_once()
+
+    def test_start_screen_recording_with_time_limit(self):
+        """Test starting screen recording with time limit."""
+        self.sr.start_screen_recording(timeLimit='60s')
+        call_kwargs = self.mock_driver.start_recording_screen.call_args[1]
+        self.assertEqual(call_kwargs['timeLimit'], 60)
+
+    def test_start_screen_recording_with_options(self):
+        """Test starting screen recording with additional options."""
+        self.sr.start_screen_recording(timeLimit='60s', bitRate=4000000)
+        call_kwargs = self.mock_driver.start_recording_screen.call_args[1]
+        self.assertEqual(call_kwargs['timeLimit'], 60)
+        self.assertEqual(call_kwargs['bitRate'], 4000000)
+
+    def test_start_screen_recording_does_not_restart_if_already_recording(self):
+        """Test that starting screen recording doesn't restart if already recording."""
+        self.sr._recording = 'existing_recording'
+        self.sr.start_screen_recording()
+        self.mock_driver.start_recording_screen.assert_not_called()
+
+    def test_stop_screen_recording_without_active_session_raises(self):
+        """Test stopping screen recording without active session raises error."""
+        with self.assertRaises(RuntimeError) as context:
+            self.sr.stop_screen_recording()
+        self.assertIn('no Active Screen Record Session', str(context.exception))
+
+    def test_stop_screen_recording_with_active_session(self):
+        """Test stopping screen recording with active session."""
+        self.sr._recording = 'active_recording'
+        self.sr._output_format = 'mp4'
+        self.mock_driver.stop_recording_screen.return_value = 'base64videodata'
+        self.sr._save_recording = mock.Mock(return_value='/tmp/logs/recording.mp4')
+        
+        result = self.sr.stop_screen_recording(filename='recording')
+        
+        self.mock_driver.stop_recording_screen.assert_called_once()
+        self.sr._save_recording.assert_called_once()
+
+    def test_stop_screen_recording_with_options(self):
+        """Test stopping screen recording with upload options."""
+        self.sr._recording = 'active_recording'
+        self.sr._output_format = 'mp4'
+        self.mock_driver.stop_recording_screen.return_value = 'base64videodata'
+        self.sr._save_recording = mock.Mock(return_value='/tmp/logs/recording.mp4')
+        
+        self.sr.stop_screen_recording(filename='recording', remotePath='http://server/upload')
+        
+        call_kwargs = self.mock_driver.stop_recording_screen.call_args[1]
+        self.assertEqual(call_kwargs['remotePath'], 'http://server/upload')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/keywords/test_screenrecord.py
+++ b/tests/keywords/test_screenrecord.py
@@ -15,7 +15,7 @@ class ScreenrecordKeywordsTests(unittest.TestCase):
         self.sr._html = mock.Mock()
         self.sr._get_log_dir = mock.Mock(return_value='/tmp/logs')
         # Mock platform detection
-        self.sr._set_output_format = mock.Mock(return_value='mp4')
+        self.sr._set_output_format = mock.Mock(return_value='.mp4')
 
     def test_initial_state(self):
         """Test initial state of screen recorder."""

--- a/tests/keywords/test_screenshot.py
+++ b/tests/keywords/test_screenshot.py
@@ -1,0 +1,69 @@
+import unittest
+import mock
+import os
+
+from AppiumLibrary.keywords._screenshot import _ScreenshotKeywords
+
+
+class ScreenshotKeywordsTests(unittest.TestCase):
+    """Tests for _ScreenshotKeywords class."""
+
+    def setUp(self):
+        """Set up the test fixture."""
+        self.ss = _ScreenshotKeywords()
+        self.mock_driver = mock.Mock()
+        self.ss._current_application = mock.Mock(return_value=self.mock_driver)
+        self.ss._html = mock.Mock()
+        self.ss._get_log_dir = mock.Mock(return_value='/tmp/logs')
+
+    def test_capture_page_screenshot_without_filename_returns_none(self):
+        """Test that capturing screenshot without filename returns None."""
+        self.mock_driver.get_screenshot_as_base64.return_value = 'base64data'
+        result = self.ss.capture_page_screenshot()
+        self.assertIsNone(result)
+
+    def test_capture_page_screenshot_without_filename_embeds_base64(self):
+        """Test that capturing screenshot without filename embeds base64 image."""
+        self.mock_driver.get_screenshot_as_base64.return_value = 'base64data'
+        self.ss.capture_page_screenshot()
+        self.ss._html.assert_called_once()
+        call_args = self.ss._html.call_args[0][0]
+        self.assertIn('base64data', call_args)
+        self.assertIn('data:image/png;base64', call_args)
+
+    def test_capture_page_screenshot_with_filename_returns_path(self):
+        """Test that capturing screenshot with filename returns the path."""
+        result = self.ss.capture_page_screenshot('screenshot.png')
+        expected_path = os.path.join('/tmp/logs', 'screenshot.png')
+        self.assertEqual(result, expected_path)
+
+    def test_capture_page_screenshot_with_filename_saves_to_file(self):
+        """Test that capturing screenshot with filename saves to file."""
+        self.ss.capture_page_screenshot('screenshot.png')
+        expected_path = os.path.join('/tmp/logs', 'screenshot.png')
+        self.mock_driver.get_screenshot_as_file.assert_called_once_with(expected_path)
+
+    def test_capture_page_screenshot_uses_save_screenshot_fallback(self):
+        """Test that save_screenshot is used if get_screenshot_as_file not available."""
+        del self.mock_driver.get_screenshot_as_file
+        self.ss.capture_page_screenshot('screenshot.png')
+        expected_path = os.path.join('/tmp/logs', 'screenshot.png')
+        self.mock_driver.save_screenshot.assert_called_once_with(expected_path)
+
+    def test_capture_page_screenshot_with_subdirectory(self):
+        """Test capturing screenshot to a subdirectory."""
+        result = self.ss.capture_page_screenshot('screenshots/test.png')
+        expected_path = os.path.join('/tmp/logs', 'screenshots', 'test.png')
+        self.assertEqual(result, expected_path)
+
+    def test_capture_page_screenshot_embeds_html_link(self):
+        """Test that screenshot with filename embeds HTML link."""
+        self.ss.capture_page_screenshot('screenshot.png')
+        self.ss._html.assert_called_once()
+        call_args = self.ss._html.call_args[0][0]
+        self.assertIn('href=', call_args)
+        self.assertIn('img src=', call_args)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/keywords/test_waiting.py
+++ b/tests/keywords/test_waiting.py
@@ -1,0 +1,150 @@
+import unittest
+import mock
+import robot.utils
+
+from AppiumLibrary.keywords._waiting import _WaitingKeywords
+
+
+class WaitingKeywordsTests(unittest.TestCase):
+    """Tests for _WaitingKeywords class."""
+
+    def setUp(self):
+        """Set up the test fixture."""
+        self.wk = _WaitingKeywords()
+        # Set a default timeout for tests
+        self.wk._timeout_in_secs = 5
+        self.wk._info = mock.Mock()
+        self.wk.log_source = mock.Mock()
+
+    def test_initial_sleep_between_wait_value(self):
+        """Test that initial sleep between wait is 0.2 seconds."""
+        self.assertEqual(self.wk._sleep_between_wait, 0.2)
+
+    def test_set_sleep_between_wait_loop(self):
+        """Test setting the sleep interval."""
+        old_value = self.wk.set_sleep_between_wait_loop(0.5)
+        self.assertEqual(old_value, 0.2)
+        self.assertEqual(self.wk._sleep_between_wait, 0.5)
+
+    def test_set_sleep_between_wait_loop_with_string(self):
+        """Test setting the sleep interval with a string value."""
+        self.wk.set_sleep_between_wait_loop(robot.utils.timestr_to_secs('1s'))
+        self.assertEqual(self.wk._sleep_between_wait, 1.0)
+
+    def test_get_sleep_between_wait_loop(self):
+        """Test getting the sleep interval."""
+        result = self.wk.get_sleep_between_wait_loop()
+        self.assertEqual(result, '200 milliseconds')
+
+    def test_get_sleep_between_wait_loop_after_set(self):
+        """Test getting the sleep interval after setting it."""
+        self.wk.set_sleep_between_wait_loop(1.0)
+        result = self.wk.get_sleep_between_wait_loop()
+        self.assertEqual(result, '1 second')
+
+    def test_format_timeout_with_string(self):
+        """Test formatting timeout with string input."""
+        result = self.wk._format_timeout('10s')
+        self.assertEqual(result, '10 seconds')
+
+    def test_format_timeout_with_none_uses_default(self):
+        """Test formatting timeout with None uses default timeout."""
+        result = self.wk._format_timeout(None)
+        self.assertEqual(result, '5 seconds')
+
+    def test_wait_until_element_is_visible_success(self):
+        """Test wait_until_element_is_visible succeeds when element is visible."""
+        self.wk._is_visible = mock.Mock(return_value=True)
+        # Should not raise
+        self.wk.wait_until_element_is_visible('locator', timeout='1s')
+        self.wk._is_visible.assert_called_with('locator')
+
+    def test_wait_until_element_is_visible_failure(self):
+        """Test wait_until_element_is_visible fails when element is not visible."""
+        self.wk._is_visible = mock.Mock(return_value=False)
+        self.wk._sleep_between_wait = 0.01  # Speed up test
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_element_is_visible('locator', timeout='0.05s')
+        self.assertIn('locator', str(context.exception))
+        self.assertIn('not visible', str(context.exception))
+
+    def test_wait_until_element_is_visible_element_not_found(self):
+        """Test wait_until_element_is_visible fails when element is not found."""
+        self.wk._is_visible = mock.Mock(return_value=None)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_element_is_visible('locator', timeout='0.05s')
+        self.assertIn('locator', str(context.exception))
+        self.assertIn('did not match', str(context.exception))
+
+    def test_wait_until_page_contains_success(self):
+        """Test wait_until_page_contains succeeds when text is present."""
+        self.wk._is_text_present = mock.Mock(return_value=True)
+        self.wk.wait_until_page_contains('expected text', timeout='1s')
+        self.wk._is_text_present.assert_called_with('expected text')
+
+    def test_wait_until_page_contains_failure(self):
+        """Test wait_until_page_contains fails when text is not present."""
+        self.wk._is_text_present = mock.Mock(return_value=False)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_page_contains('expected text', timeout='0.05s')
+        self.assertIn('expected text', str(context.exception))
+        self.assertIn('did not appear', str(context.exception))
+
+    def test_wait_until_page_does_not_contain_success(self):
+        """Test wait_until_page_does_not_contain succeeds when text disappears."""
+        self.wk._is_text_present = mock.Mock(return_value=False)
+        self.wk.wait_until_page_does_not_contain('text to disappear', timeout='1s')
+        self.wk._is_text_present.assert_called_with('text to disappear')
+
+    def test_wait_until_page_does_not_contain_failure(self):
+        """Test wait_until_page_does_not_contain fails when text remains."""
+        self.wk._is_text_present = mock.Mock(return_value=True)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_page_does_not_contain('persistent text', timeout='0.05s')
+        self.assertIn('persistent text', str(context.exception))
+        self.assertIn('did not disappear', str(context.exception))
+
+    def test_wait_until_page_contains_element_success(self):
+        """Test wait_until_page_contains_element succeeds when element appears."""
+        self.wk._is_element_present = mock.Mock(return_value=True)
+        self.wk.wait_until_page_contains_element('//button', timeout='1s')
+        self.wk._is_element_present.assert_called_with('//button')
+
+    def test_wait_until_page_contains_element_failure(self):
+        """Test wait_until_page_contains_element fails when element does not appear."""
+        self.wk._is_element_present = mock.Mock(return_value=False)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_page_contains_element('//button', timeout='0.05s')
+        self.assertIn('//button', str(context.exception))
+        self.assertIn('did not appear', str(context.exception))
+
+    def test_wait_until_page_does_not_contain_element_success(self):
+        """Test wait_until_page_does_not_contain_element succeeds when element disappears."""
+        self.wk._is_element_present = mock.Mock(return_value=False)
+        self.wk.wait_until_page_does_not_contain_element('//spinner', timeout='1s')
+        self.wk._is_element_present.assert_called_with('//spinner')
+
+    def test_wait_until_page_does_not_contain_element_failure(self):
+        """Test wait_until_page_does_not_contain_element fails when element remains."""
+        self.wk._is_element_present = mock.Mock(return_value=True)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_page_does_not_contain_element('//spinner', timeout='0.05s')
+        self.assertIn('//spinner', str(context.exception))
+        self.assertIn('did not disappear', str(context.exception))
+
+    def test_wait_until_custom_error_message(self):
+        """Test that custom error message is used."""
+        self.wk._is_text_present = mock.Mock(return_value=False)
+        self.wk._sleep_between_wait = 0.01
+        with self.assertRaises(AssertionError) as context:
+            self.wk.wait_until_page_contains('text', timeout='0.05s', error='Custom error message')
+        self.assertIn('Custom error message', str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/keywords/test_waiting.py
+++ b/tests/keywords/test_waiting.py
@@ -28,7 +28,7 @@ class WaitingKeywordsTests(unittest.TestCase):
 
     def test_set_sleep_between_wait_loop_with_string(self):
         """Test setting the sleep interval with a string value."""
-        self.wk.set_sleep_between_wait_loop(robot.utils.timestr_to_secs('1s'))
+        self.wk.set_sleep_between_wait_loop('1s')
         self.assertEqual(self.wk._sleep_between_wait, 1.0)
 
     def test_get_sleep_between_wait_loop(self):


### PR DESCRIPTION
- Add tests for _keyevent.py (100% coverage)
- Add tests for _runonfailure.py (81% coverage)
- Add tests for _screenshot.py (100% coverage)
- Add tests for _screenrecord.py (57% coverage)
- Add tests for _waiting.py (100% coverage)

Improves overall test coverage from 33% to 39%

## Implements
This pull request adds comprehensive unit tests for several internal keyword classes in the AppiumLibrary, significantly improving test coverage for key functionalities such as key events, run-on-failure behavior, screen recording, screenshots, and waiting mechanisms. The new tests use Python's `unittest` framework and extensive mocking to verify correct behavior under various scenarios, including edge cases and error handling.

**New Unit Test Coverage:**

* **Key Event Keywords:**
  - Added tests for `_KeyeventKeywords`, covering `press_keycode` and `long_press_keycode` methods, including handling of meta states and string-to-int conversion.

* **Run-On-Failure Keywords:**
  - Introduced tests for `_RunOnFailureKeywords`, verifying registration, state transitions, disabling, and error reporting logic for run-on-failure keywords.

* **Screen Recording Keywords:**
  - Implemented tests for `_ScreenrecordKeywords`, checking start/stop behavior, time limits, output format handling, prevention of duplicate recordings, and error handling for missing sessions.

* **Screenshot Keywords:**
  - Added tests for `_ScreenshotKeywords`, ensuring correct screenshot capture with and without filenames, file saving, fallback mechanisms, subdirectory handling, and HTML embedding.

* **Waiting Keywords:**
  - Developed tests for `_WaitingKeywords`, covering sleep interval management, timeout formatting, and all major wait-until behaviors (element/text presence/absence), including error and edge cases.
