### PR TITLE
Optimize tap loop by hoisting element finding and calculations

### DIFF
--- a/AppiumLibrary/keywords/_touch.py
+++ b/AppiumLibrary/keywords/_touch.py
@@ -326,12 +326,12 @@ class _TouchKeywords(KeywordGroup):
                 raise ValueError(f"Invalid coordinates format: {element}. Expected a list like [x, y]")
             
         elif isinstance(element, str):
+            el = self._element_find(element, True, True)
+            location = el.location
+            size = el.size
+            center_x = location['x'] + size['width'] // 2
+            center_y = location['y'] + size['height'] // 2
             for _ in range(count):
-                el = self._element_find(element, True, True)
-                location = el.location
-                size = el.size
-                center_x = location['x'] + size['width'] // 2
-                center_y = location['y'] + size['height'] // 2
                 driver.tap([(center_x, center_y)], duration.total_seconds() * 1000)
 
         else:


### PR DESCRIPTION
## Implements
This pull request makes a small adjustment to the `tap` method in the `AppiumLibrary/keywords/_touch.py` file. The change corrects the placement of the loop that handles multiple taps when the `element` is a string locator, ensuring that the element is only found once and then tapped multiple times as intended.

- Fixed the `tap` method so that when tapping on an element found by a string locator, the element is located once and then tapped the specified number of times, improving efficiency and correctness.
## Fixing
