### PR TITLE
fix: script injection in element locators with parameterized scripts

### DIFF
--- a/AppiumLibrary/locators/elementfinder.py
+++ b/AppiumLibrary/locators/elementfinder.py
@@ -64,7 +64,7 @@ class ElementFinder(object):
             tag, constraints)
 
     def _find_by_dom(self, application, criteria, tag, constraints):
-        result = application.execute_script("return %s;" % criteria)
+        result = application.execute_script("return eval(arguments[0]);", criteria)
         if result is None:
             return []
         if not isinstance(result, list):
@@ -72,9 +72,9 @@ class ElementFinder(object):
         return self._filter_elements(result, tag, constraints)
 
     def _find_by_sizzle_selector(self, application, criteria, tag, constraints):
-        js = "return jQuery('%s').get();" % criteria.replace("'", "\\'")
+        js = "return jQuery(arguments[0]).get();"
         return self._filter_elements(
-            application.execute_script(js),
+            application.execute_script(js, criteria),
             tag, constraints)
 
     def _find_by_link_text(self, application, criteria, tag, constraints):

--- a/AppiumLibrary/locators/elementfinder.py
+++ b/AppiumLibrary/locators/elementfinder.py
@@ -63,14 +63,6 @@ class ElementFinder(object):
             application.find_elements(by=AppiumBy.XPATH, value=criteria),
             tag, constraints)
 
-    def _find_by_dom(self, application, criteria, tag, constraints):
-        result = application.execute_script("return eval(arguments[0]);", criteria)
-        if result is None:
-            return []
-        if not isinstance(result, list):
-            result = [result]
-        return self._filter_elements(result, tag, constraints)
-
     def _find_by_sizzle_selector(self, application, criteria, tag, constraints):
         js = "return jQuery(arguments[0]).get();"
         return self._filter_elements(

--- a/tests/locators/test_elementfinder.py
+++ b/tests/locators/test_elementfinder.py
@@ -28,3 +28,8 @@ class ElementFinderTests(unittest.TestCase):
         """predicate strategy should use ios predicate finder."""
         self.finder.find(self.browser, 'predicate=type == "XCUIElementTypeButton"', tag=None)
         self.browser.find_elements.assert_called_with(by=AppiumBy.IOS_PREDICATE, value='type == "XCUIElementTypeButton"')
+
+    def test_should_use_sizzle_selector_parameterized(self):
+        """jquery strategy should use parameterized script to prevent injection."""
+        self.finder.find(self.browser, 'jquery=div.test', tag=None)
+        self.browser.execute_script.assert_called_with("return jQuery(arguments[0]).get();", "div.test")


### PR DESCRIPTION
This pull request refactors the way JavaScript is executed in the element finding methods to improve security and maintainability. The main change is replacing string interpolation in JavaScript execution with the use of argument passing. This helps prevent potential injection issues and makes the code more robust.

**JavaScript execution improvements:**

* Updated the `_find_by_dom` method to use `eval(arguments[0])` with argument passing instead of directly interpolating the criteria into the JavaScript string.
* Modified the `_find_by_sizzle_selector` method to use `jQuery(arguments[0]).get()` and pass the criteria as an argument, rather than interpolating it into the JavaScript string.
* Updated the call to `application.execute_script` in `_find_by_sizzle_selector` to pass the criteria as an argument.