### PR TITLE
🔒 Fix potential XPath injection in _element_find_by_text

### DIFF
--- a/AppiumLibrary/keywords/_element.py
+++ b/AppiumLibrary/keywords/_element.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from AppiumLibrary import utils
 from AppiumLibrary.locators import ElementFinder
 from appium.webdriver.common.appiumby import AppiumBy
 from .keywordgroup import KeywordGroup
@@ -724,16 +725,18 @@ class _ElementKeywords(KeywordGroup):
             if element:
                 return element
             else:
+                _text = utils.escape_xpath_value(text)
                 if exact_match:
-                    _xpath = u'//*[@value="{}" or @label="{}"]'.format(text, text)
+                    _xpath = u'//*[@value={text} or @label={text}]'.format(text=_text)
                 else:
-                    _xpath = u'//*[contains(@label,"{}") or contains(@value, "{}")]'.format(text, text)
+                    _xpath = u'//*[contains(@label,{text}) or contains(@value, {text})]'.format(text=_text)
                 return self._element_find(_xpath, True, True)
         elif self._get_platform() == 'android':
+            _text = utils.escape_xpath_value(text)
             if exact_match:
-                _xpath = u'//*[@{}="{}"]'.format('text', text)
+                _xpath = u'//*[@{attr}={text}]'.format(attr='text', text=_text)
             else:
-                _xpath = u'//*[contains(@{},"{}")]'.format('text', text)
+                _xpath = u'//*[contains(@{attr},{text})]'.format(attr='text', text=_text)
             return self._element_find(_xpath, True, True)
 
     def _get_text(self, locator, first_only: bool = True):

--- a/tests/keywords/test_element_security.py
+++ b/tests/keywords/test_element_security.py
@@ -1,0 +1,64 @@
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+from AppiumLibrary.keywords._element import _ElementKeywords
+from AppiumLibrary import utils
+from appium.webdriver.common.appiumby import AppiumBy
+
+class ElementSecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.element_keywords = _ElementKeywords()
+        self.driver = mock.Mock()
+        self.element_keywords._current_application = mock.Mock(return_value=self.driver)
+        # Mocking _info to avoid issues with BuiltIn
+        self.element_keywords._info = mock.Mock()
+
+    def test_android_exact_match_secure(self):
+        self.element_keywords._get_platform = mock.Mock(return_value='android')
+        self.element_keywords._element_find = mock.Mock(return_value=mock.Mock())
+        malicious_text = '"] | //*[@text="injected'
+
+        self.element_keywords._element_find_by_text(malicious_text, exact_match=True)
+
+        escaped_text = utils.escape_xpath_value(malicious_text)
+        # Now it should be //*[@text=concat('"', "'] | //*[@text=", '"', "injected")]
+        expected_xpath = u'//*[@text={}]'.format(escaped_text)
+        self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)
+
+    def test_android_contains_match_secure(self):
+        self.element_keywords._get_platform = mock.Mock(return_value='android')
+        self.element_keywords._element_find = mock.Mock(return_value=mock.Mock())
+        malicious_text = '")] | //*[@text="injected'
+
+        self.element_keywords._element_find_by_text(malicious_text, exact_match=False)
+
+        escaped_text = utils.escape_xpath_value(malicious_text)
+        expected_xpath = u'//*[contains(@text,{})]'.format(escaped_text)
+        self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)
+
+    def test_ios_exact_match_secure(self):
+        self.element_keywords._get_platform = mock.Mock(return_value='ios')
+        # ios first tries to find by text directly (not via xpath)
+        self.element_keywords._element_find = mock.Mock(side_effect=[None, mock.Mock()])
+
+        malicious_text = '"] | //*[@label="injected'
+
+        self.element_keywords._element_find_by_text(malicious_text, exact_match=True)
+
+        escaped_text = utils.escape_xpath_value(malicious_text)
+        expected_xpath = u'//*[@value={text} or @label={text}]'.format(text=escaped_text)
+        self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)
+
+    def test_ios_contains_match_secure(self):
+        self.element_keywords._get_platform = mock.Mock(return_value='ios')
+        self.element_keywords._element_find = mock.Mock(side_effect=[None, mock.Mock()])
+
+        malicious_text = '")] | //*[@label="injected'
+
+        self.element_keywords._element_find_by_text(malicious_text, exact_match=False)
+
+        escaped_text = utils.escape_xpath_value(malicious_text)
+        expected_xpath = u'//*[contains(@label,{text}) or contains(@value, {text})]'.format(text=escaped_text)
+        self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)

--- a/tests/keywords/test_element_security.py
+++ b/tests/keywords/test_element_security.py
@@ -62,3 +62,14 @@ class ElementSecurityTests(unittest.TestCase):
         escaped_text = utils.escape_xpath_value(malicious_text)
         expected_xpath = u'//*[contains(@label,{text}) or contains(@value, {text})]'.format(text=escaped_text)
         self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)
+
+    def test_mixed_quotes_secure(self):
+        self.element_keywords._get_platform = mock.Mock(return_value='android')
+        self.element_keywords._element_find = mock.Mock(return_value=mock.Mock())
+        malicious_text = 'a\'b"c'
+
+        self.element_keywords._element_find_by_text(malicious_text, exact_match=True)
+
+        escaped_text = utils.escape_xpath_value(malicious_text)
+        expected_xpath = u'//*[@text={}]'.format(escaped_text)
+        self.element_keywords._element_find.assert_any_call(expected_xpath, True, True)


### PR DESCRIPTION
The input string 'text' was directly concatenated into the XPath query using format(), which could allow a malicious user to manipulate the XPath structure. This is fixed by using the utility function escape_xpath_value() and updating the XPath templates to work with the escaped (and already quoted) values.

PR Title: 🔒 [security fix potential XPath injection in _element_find_by_text]

🎯 What: Fixed potential XPath injection vulnerability in the `_element_find_by_text` method.
⚠️ Risk: Malicious input could be used to manipulate XPath queries, potentially allowing unauthorized access to elements or data within the application.
🛡️ Solution: Applied `utils.escape_xpath_value()` to the `text` parameter before incorporating it into XPath strings. Refactored the XPath templates to remove hardcoded quotes. Added comprehensive unit tests in `tests/keywords/test_element_security.py` to verify the fix.

## Implements

## Fixing
