### PR TITLE
Declare Python 3.14 support and unify version information

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 History
 =======
+Unreleased
+----------------
+- Declare Python 3.14 support: added the ``3.14`` trove classifier, marked the
+  README accordingly and set ``requires-python = ">=3.9"`` so the supported
+  range is stated consistently in one machine-readable place (#476)
+
 3.2.1
 ----------------
 - Fixed botched v3.2 release leaving out the fix for Robot Framework 7.4

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ AppiumLibrary_ is an appium testing library for `Robot Framework`_. Library can 
 It uses `Appium <http://appium.io/>`_ to communicate with Android and iOS application
 similar to how *Selenium WebDriver* talks to web browser.
 
-It is supporting Python 3.9+ and Appium Python Client 5.1.1+
+It is supporting Python 3.9+ (tested up to Python 3.14) and Appium Python Client 5.1.1+
 
 .. image:: https://img.shields.io/pypi/v/robotframework-appiumlibrary.svg
     :target: https://pypi.python.org/pypi/robotframework-appiumlibrary/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 ]
 description = "Robot Framework Mobile app testing library for Appium Client Android & iOS & Web"
 readme = "README.rst"
+requires-python = ">=3.9"
 authors = [
     {name = "MarketSquare - Robot Framework community"},
     {name = "William Zhang"},
@@ -42,6 +43,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Robot Framework",
     "Framework :: Robot Framework :: Library",
 ]


### PR DESCRIPTION
Fixes #476

The README claimed Python 3.9+ while the v3.2.1 release notes said 3.9–3.13, and `pyproject.toml` had neither a `requires-python` marker nor a 3.14 classifier. This PR unifies the version information:

- **`pyproject.toml`**: added the `Programming Language :: Python :: 3.14` trove classifier and set `requires-python = ">=3.9"` — the single machine-readable statement of the supported floor, so pip/PyPI enforce and display it consistently from now on.
- **`README.rst`**: states the tested range explicitly: *Python 3.9+ (tested up to Python 3.14)*.
- **`CHANGES.rst`**: entry under *Unreleased*.

**Verification on Python 3.14.6:** full unit test suite passes, library import/instantiation works, and Libdoc generates all 110 keywords. Also built the wheel and confirmed the metadata contains `Requires-Python: >=3.9` and the 3.14 classifier.